### PR TITLE
Removed the eye-eating color

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -8,9 +8,7 @@ async function GetSelectedText() {
 	let decoded = unicodeToChar(text);
 	decorations.push(editor.selection)
 
-	let style = vscode.window.createTextEditorDecorationType({ color: "white", backgroundColor: "#cf6a87" });
-	editor.setDecorations(style, decorations);
-
+	
 	editor.edit(function (editBuilder) {
 		editBuilder.replace(editor.selection, decoded);
 	});


### PR DESCRIPTION
As a user, I was very surprised by the selection of the changed text in color (and a very unpleasant color for a dark IDE theme). In my case, I want to decode everything (CMD+A --> decode). It seems that highlighting with color only gets in the way.